### PR TITLE
Fix --pq flag not being passed in recipients subcommand

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -36,7 +36,7 @@ struct CLI {
           input = try String(data: FileHandle.standardInput.readToEnd()!, encoding: .utf8)!
         }
         let result = try plugin.generateRecipients(
-          input: input, recipientType: options.recipientType.recipientType)
+          input: input, recipientType: options.recipientType.recipientType, pq: options.pq)
         if let outputFile = options.output {
           FileManager.default.createFile(
             atPath: outputFile,


### PR DESCRIPTION
## Summary

- Fix `--pq` flag being ignored in the `recipients` subcommand
- The `pq` parameter was not being passed to `generateRecipients()`, so it always defaulted to `false`

## Before / After

### Before

<img width="1420" height="260" alt="age-plugin-se-before" src="https://github.com/user-attachments/assets/3ff33431-f6f3-4d27-9d12-c3fd62b141a2" />

### After

<img width="1420" height="396" alt="age-plugin-se-after" src="https://github.com/user-attachments/assets/bf6d19eb-9127-47fe-abe7-41796c17e604" />

## Details

The `keygen` subcommand correctly passed `pq: options.pq` to `generateKey()`, but the `recipients` subcommand was missing this parameter in the call to `generateRecipients()`, causing `--pq` to have no effect.