### PR TITLE
Fix identity encryption always using piv-p256 instead of p256tag/mlkem768p256tag

### DIFF
--- a/Sources/Plugin.swift
+++ b/Sources/Plugin.swift
@@ -146,10 +146,11 @@ class Plugin {
     }
     for (index, identity) in identities.enumerated() {
       do {
+        let id = try Identity(ageIdentity: identity, crypto: crypto)
         recipientKeys.append(
           (
-            (try Identity(ageIdentity: identity, crypto: crypto)).recipient,
-            .pivp256
+            id.recipient,
+            id.recipient.mlkem768PublicKey != nil ? .mlkem768p256tag : .p256tag
           ))
       } catch {
         errors.append(


### PR DESCRIPTION
## Summary

- When encrypting with an identity (`-i`), the plugin always used `piv-p256` stanza type, ignoring post-quantum keys
- Now uses `mlkem768p256tag` when the identity has ML-KEM keys, and `p256tag` otherwise
- Aligns with `age-plugin-yubikey` behavior of always using modern stanza types for encryption

## Before / After

### Before

<img width="1420" height="292" alt="age-plugin-se-before" src="https://github.com/user-attachments/assets/ac668ea0-4a08-4bc9-8515-ae970823d99c" />

### After

<img width="1420" height="292" alt="age-plugin-se-after" src="https://github.com/user-attachments/assets/b309ec46-4440-4963-875e-bb259fdb3f8b" />

## Details

The `runRecipientV1` function hardcoded `.pivp256` for all identities passed via
`add-identity`, even when the identity contained ML-KEM-768 keys generated with `--pq`.
This meant `age -e -i key.txt` never used post-quantum encryption.

Recipients passed via `add-recipient` (`-r`) already correctly detected the stanza type
from the recipient string prefix. This fix applies equivalent logic for identities,
using the available key material to determine the appropriate stanza type.