### PR TITLE
Add ISO 8601 fallback for older Swift

### DIFF
--- a/Sources/Plugin.swift
+++ b/Sources/Plugin.swift
@@ -21,7 +21,11 @@ class Plugin {
     if !crypto.isSecureEnclaveAvailable {
       throw Error.seUnsupported
     }
-    let createdAt = now.ISO8601Format()
+    #if compiler(>=6.2)
+      let createdAt = now.ISO8601Format()
+    #else
+      let createdAt = ISO8601DateFormatter().string(from: now)
+    #endif
     #if !os(Linux) && !os(Windows)
       var accessControlFlags: SecAccessControlCreateFlags = [.privateKeyUsage]
       if accessControl == .anyBiometry || accessControl == .anyBiometryAndPasscode {


### PR DESCRIPTION
## Summary

- keep `Date.ISO8601Format()` for Swift 6.2 and newer
- use `ISO8601DateFormatter().string(from:)` with older compilers
- preserve the generated identity format without expanding the supported toolchain policy

Swift 5.10.1's Linux corelibs Foundation does not provide `Date.ISO8601Format()`. The compiler guard keeps the current API on the supported Swift 6.2 path while allowing downstream legacy builds to use the portable formatter.

Closes #20

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make test` (105 tests)
- strict `swift-format` lint over `Package.swift Sources Scripts Tests`
- `git diff --check`
- Nixpkgs Swift 5.10.1 builds for `aarch64-linux` and `x86_64-linux`, using this source without the downstream formatter substitution

AI disclosure: prepared with assistance from OpenAI Codex (GPT-5).
